### PR TITLE
No longer interrupt when reporting progress in patching

### DIFF
--- a/src/OperationPanel.cs
+++ b/src/OperationPanel.cs
@@ -74,7 +74,7 @@ public class OperationPanel : FlowLayoutPanel
             if (label.Text != value)
             {
                 label.Text = value;
-                label.AccessibilityObject.RaiseAutomationNotification(AutomationNotificationKind.Other, AutomationNotificationProcessing.ImportantMostRecent, value);
+                label.AccessibilityObject.RaiseAutomationNotification(AutomationNotificationKind.Other, AutomationNotificationProcessing.All, value);
                 AddHistoryItem(value);
             }
         }


### PR DESCRIPTION
The bug was caused by the "done" notification being delayed and arriving while the screenreader is speaking the message box's contents. Fixing this is Simply changing AutomationProcessing in OperationPanel to ALL which no longer interrupts.