### PR TITLE
Revert to x86 target and persist installation path via AppData config file

### DIFF
--- a/HearthstoneAccessPatcher.csproj
+++ b/HearthstoneAccessPatcher.csproj
@@ -9,8 +9,8 @@
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <PlatformTarget>x64</PlatformTarget>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PlatformTarget>x86</PlatformTarget>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
 
     <!-- Globalization settings to reduce size -->
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/src/MainForm.cs
+++ b/src/MainForm.cs
@@ -109,8 +109,7 @@ public class MainForm : Form
                     if (Patcher.IsHsDirectory(selectedPath))
                     {
                         directoryBox.Text = selectedPath;
-                        // Persist the custom directory to environment variable for user
-                        Environment.SetEnvironmentVariable("HEARTHSTONE_HOME", selectedPath, EnvironmentVariableTarget.User);
+                        Patcher.SaveHearthstonePath(selectedPath);
                     }
                     else
                     {
@@ -253,10 +252,7 @@ public class MainForm : Form
             await Task.Run(() => Patcher.UnpackAndPatch(cachedPatchFile, directory, placeChangelog));
 
             operationPanel.LabelText = "Done.";
-
-            // Persist the directory to environment variable for user after successful patch
-            Environment.SetEnvironmentVariable("HEARTHSTONE_HOME", directory, EnvironmentVariableTarget.User);
-
+            Patcher.SaveHearthstonePath(directory);
             MessageBox.Show("Hearthstone patched successfully!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
 
             // Clean up cached file after successful patch

--- a/src/Patcher.cs
+++ b/src/Patcher.cs
@@ -16,24 +16,32 @@ static class Patcher
         return false;
     }
 
+    private static string ConfigFilePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "HearthstoneAccessPatcher",
+        "hearthstone_path.txt"
+    );
+
+    public static void SaveHearthstonePath(string path)
+    {
+        string dir = Path.GetDirectoryName(ConfigFilePath)!;
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(ConfigFilePath, path);
+    }
+
     public static string? LocateHearthstone()
     {
-        string? path = Environment.GetEnvironmentVariable("HEARTHSTONE_HOME");
-        if (path != null && IsHsDirectory(path))
+        if (File.Exists(ConfigFilePath))
         {
-            return Path.GetFullPath(path);
-        }
-        string programFiles;
-        if (Environment.Is64BitOperatingSystem)
-        {
-            programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
-        }
-        else
-        {
-            programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+            string? saved = File.ReadAllText(ConfigFilePath).Trim();
+            if (IsHsDirectory(saved))
+                return Path.GetFullPath(saved);
         }
 
-        path = Path.Combine(programFiles, "Hearthstone");
+        string programFiles = Environment.Is64BitOperatingSystem
+            ? Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)
+            : Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        string path = Path.Combine(programFiles, "Hearthstone");
         if (IsHsDirectory(path))
         {
             return path;


### PR DESCRIPTION
Hearthstone and HearthstoneAccess support 32-bit, so the build target is reverted from x64 back to x86.

The custom installation path is now saved to %APPDATA%\HearthstoneAccessPatcher\hearthstone_path.txt instead of the HEARTHSTONE_HOME user environment variable.